### PR TITLE
Update tasks.py

### DIFF
--- a/library_management/tasks.py
+++ b/library_management/tasks.py
@@ -30,7 +30,7 @@ def get_overdue(loan_period):
 	overdue_by_member = {}
 	articles_transacted = []
 
-	for d in frappe.db.sql("""select name, article, article_name, library_member, member_name
+	for d in frappe.db.sql("""select name, article, article_name, library_member, member_name , transaction_type
 		from `tabLibrary Transaction` order by transaction_date desc, modified desc""", as_dict=1):
 
 		if d.article in articles_transacted:


### PR DESCRIPTION
```
    for d in frappe.db.sql("""select name, article, article_name, library_member, member_name
        from `tabLibrary Transaction` order by transaction_date desc, modified desc""", as_dict=1):
        continue

    if d.transaction_type=="Issue" and date_diff(today, d.transaction_date) > loan_period:
        overdue_by_member.setdefault(d.library_member, [])
        overdue_by_member[d.library_member].append(d)
```

here, in the query there was no  "transaction_type" fetched. But, it was used in next section
